### PR TITLE
[YUNIKORN-424] Fix nonstandard title grammar for the markdown file

### DIFF
--- a/docs/design/scheduler_core_design.md
+++ b/docs/design/scheduler_core_design.md
@@ -62,7 +62,7 @@ Scheduler core is agnostic about underneath platforms, all the communications ar
                 +---------------------------------------------+
 ```
 
-###Scheduler API Server (RMProxy)
+### Scheduler API Server (RMProxy)
 
 Responsible for communication between RM and Scheduler, which implements scheduler-interface GRPC protocol,
 or just APIs. (For intra-process communication w/o Serde).


### PR DESCRIPTION
The current grammar will cause the title rendering to fail, the case is here: http://yunikorn.apache.org/docs/next/design/scheduler_core_design/