### PR TITLE
[YUNIKORN-944] Fix build dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM node:12.18.0
+FROM node:16.13.0
 
 ADD . /incubator-yunikorn-site
 WORKDIR /incubator-yunikorn-site

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Instead of running the build inside a docker image you can also run it locally w
 This is faster than running the build inside a docker image:
 ```shell script
 yarn install
+yarn add @docusaurus/theme-search-algolia
 yarn build
 yarn run start
 ```

--- a/local-build.sh
+++ b/local-build.sh
@@ -34,7 +34,7 @@ function clean() {
 function build() {
   # build local docker image
   cat <<EOF >.dockerfile.tmp
-FROM node:12.18.0
+FROM node:16.13.0
 ADD . /incubator-yunikorn-site
 WORKDIR /incubator-yunikorn-site
 EOF
@@ -57,6 +57,10 @@ function run() {
   # install dependency in docker container
   docker exec -it yunikorn-site-local /bin/bash -c "yarn install"
   [ "$?" -ne 0 ] && echo "yarn install failed" && return 1
+
+  # install dependency in docker container
+  docker exec -it yunikorn-site-local /bin/bash -c "yarn add @docusaurus/theme-search-algolia"
+  [ "$?" -ne 0 ] && echo "yarn add failed" && return 1
 
   # run build inside the container
   docker exec -it yunikorn-site-local /bin/bash -c "yarn build"

--- a/package.json
+++ b/package.json
@@ -10,9 +10,9 @@
     "release": "docusaurus docs:version"
   },
   "dependencies": {
-    "@docusaurus/core": "2.0.0-alpha.63",
-    "@docusaurus/preset-classic": "2.0.0-alpha.63",
-    "@docusaurus/theme-search-algolia": "^2.0.0-beta.3",
+    "@docusaurus/core": "2.0.0-beta.9",
+    "@docusaurus/preset-classic": "2.0.0-beta.9",
+    "@docusaurus/theme-search-algolia": "^2.0.0-beta.9",
     "@mdx-js/react": "^1.5.8",
     "clsx": "^1.1.1",
     "react": "16.13.1",


### PR DESCRIPTION
The search theme requires a later version of node.js to build.
Fix the local build script and the README to add the search dependency.
Update node to the current release 16.13.
Upgrade docusaurus to the latest v2 beta release (moving away from the
current alpha release)