### PR TITLE
[YUNIKORN-1021] Add committer/PPMC user list on the website.

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -94,6 +94,10 @@ module.exports = {
               to: 'community/events',
               label: 'Events',
             },
+            {
+              to: 'community/people',
+              label: 'People',
+            },
           ]
         },
         {

--- a/src/pages/community/get_involved.md
+++ b/src/pages/community/get_involved.md
@@ -76,44 +76,6 @@ import TabItem from '@theme/TabItem';
 
 - Calendar: [Google Calendar](https://calendar.google.com/calendar/u/0?cid=YXBhY2hlLnl1bmlrb3JuQGdtYWlsLmNvbQ) :point_left:
 
-## Become a Committer
-
-Committers are the community members who have the write access to the project's repositories, i.e
-they can modify the code by themselves and accept others contributions to all YuniKorn repos.
-There is no strict rules about the qualification of a candidate. The PPMC votes for a candidate
-based on various considerations:
-
-- Code contributions
-  - Consistent code contributions
-  - Optimize the CI/CD pipeline
-  - Help with the code reviews
-  - Test and verify release candidates
-  - Performance tuning and related tools development
-  - Propose improvement proposals
-
-- Non-code contributions
-  - Involvement in the community activities, such as meetings, meetups, etc.
-  - Provide feedback, report issues, and participate in roadmap discussions
-  - Help on project releases
-  - Improve project documentation
-  - Help the project adoption
-  - Integrate with other projects, extend the use cases
-
-Contributor or non-contributor can both make their paths to committer, the community deeply
-appreciates both code or non-code contributions.
-
-## Become a PPMC member
-
-PPMC stands for the Podling Project Management Committee. It is responsible for project
-management, governance and ensures the project can be operated under the [Apache Way](https://www.apache.org/theapacheway/).
-The committee makes decisions based on the PPMC members' votes. A PPMC member has the authority to cast a binding
-vote on various things, such as project releases, adding new committer or PPMC member, etc.
-
-A contributor must become a committer first before becoming a PPMC member.
-There is no strict rules of when a committer will be qualified for being added to PPMC. The management
-committee makes a decision based on the involvement and impact of each committer. In general, a committer
-who makes consistent code or non-code contributions to the project should be considered as a PPMC candidate.
-
 ## How to share feedback to YuniKorn Community
 
 We welcome you to try our latest releases and share your experiences.

--- a/src/pages/community/people.md
+++ b/src/pages/community/people.md
@@ -1,0 +1,104 @@
+---
+id: people
+title: Who We Are
+---
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+## Project Members
+
+YuniKorn community is open, diverse, and collaborative. It is not owned
+by any entity. Project members share the responsibility to manage, and maintain the project.
+People in the community includes PPMC ([Podling Project Management Committee](https://incubator.apache.org/guides/ppmc.html))
+members and [committers](https://infra.apache.org/new-committers-guide.html#what-is-a-committer).
+
+
+## PPMC
+
+| Public Name             	| ApacheID   	| Organization 	| Timezone (UTC) 	|
+|-------------------------	|------------	|--------------	|----------------	|
+| Akhil PB                	| akhilpb    	| Cloudera     	| +5.5           	|
+| Arun Suresh             	| asuresh    	| Oracle       	| -8             	|
+| Carlo Curino            	| curino     	| Microsoft    	| -8             	|
+| Chaoran Yu              	| yuchaoran  	| Apple        	| -8             	|
+| Chenya Zhang            	| chenya     	| Apple        	| -8             	|
+| Craig Condit            	| ccondit    	| Cloudera     	| -8             	|
+| DB Tsai                 	| dbtsai     	| Apple        	| -8             	|
+| Jonathan Hung           	| jhung      	| LinkedIn     	| -8             	|
+| Kinga Marton            	| kmarton    	| Cloudera     	| +1             	|
+| Konstantinos Karanasos  	| kkaranasos 	| Microsoft    	| -8             	|
+| Subramaniam Krishnan    	| subru      	| Microsoft    	| -8             	|
+| Sunil Govindan          	| sunilg     	| Cloudera     	| -8             	|
+| Tao Yang                	| taoyang    	| Alibaba      	| +8             	|
+| Vinod Kumar Vavilapalli 	| vinodkv    	| Cloudera     	| +5.5           	|
+| Wangda Tan              	| wangda     	| Snowflake    	| -8             	|
+| Weiwei Yang             	| wwei       	| Cloudera     	| -8             	|
+| Wilfred Spiegelenburg   	| wilfreds   	| Cloudera     	| +11            	|
+
+## Committer
+
+> The listing below excludes the PPMC members
+
+| Name                    	| ApacheID   	| Organization 	| Timezone 	|
+|-------------------------	|------------	|--------------	|----------	|
+| Chia-Ping Tsai          	| chia7712   	| Is-Land      	| +8       	|
+| Li Gao                  	| ligao      	| Databricks   	| -8       	|
+| Manikandan R            	| mani       	| Caastle      	| +5.5     	|
+| Peter Bacsko            	| pbacsko    	| Cloudera     	| +1       	|
+| Tingyao Huang           	| tingyao    	|              	| +8       	|
+| Yu Teng Chen            	| yuteng     	| NTCU         	| +8       	|
+
+## Become a Committer
+
+Committers are the community members who have the write access to the project's repositories, i.e
+they can modify the code by themselves and accept others contributions to all YuniKorn repos.
+There is no strict rules about the qualification of a candidate. The PPMC votes for a candidate
+based on various considerations:
+
+- Code contributions
+    - Consistent code contributions
+    - Optimize the CI/CD pipeline
+    - Help with the code reviews
+    - Test and verify release candidates
+    - Performance tuning and related tools development
+    - Propose improvement proposals
+
+- Non-code contributions
+    - Involvement in the community activities, such as meetings, meetups, etc.
+    - Provide feedback, report issues, and participate in roadmap discussions
+    - Help on project releases
+    - Improve project documentation
+    - Help the project adoption
+    - Integrate with other projects, extend the use cases
+
+Contributor or non-contributor can both make their paths to committer, the community deeply
+appreciates both code or non-code contributions.
+
+## Become a PPMC member
+
+PPMC stands for the Podling Project Management Committee. It is responsible for project
+management, governance and ensures the project can be operated under the [Apache Way](https://www.apache.org/theapacheway/).
+The committee makes decisions based on the PPMC members' votes. A PPMC member has the authority to cast a binding
+vote on various things, such as project releases, adding new committer or PPMC member, etc.
+
+A contributor must become a committer first before becoming a PPMC member.
+There is no strict rules of when a committer will be qualified for being added to PPMC. The management
+committee makes a decision based on the involvement and impact of each committer. In general, a committer
+who makes consistent code or non-code contributions to the project should be considered as a PPMC candidate.

--- a/src/pages/community/people.md
+++ b/src/pages/community/people.md
@@ -26,7 +26,7 @@ under the License.
 
 YuniKorn community is open, diverse, and collaborative. It is not owned
 by any entity. Project members share the responsibility to manage, and maintain the project.
-People in the community includes PPMC ([Podling Project Management Committee](https://incubator.apache.org/guides/ppmc.html))
+People in the community include Podling Project Management Committee ([PPMC](https://incubator.apache.org/guides/ppmc.html))
 members and [committers](https://infra.apache.org/new-committers-guide.html#what-is-a-committer).
 
 
@@ -62,7 +62,7 @@ members and [committers](https://infra.apache.org/new-committers-guide.html#what
 | Li Gao                  	| ligao      	| Databricks   	| -8       	|
 | Manikandan R            	| mani       	| Caastle      	| +5.5     	|
 | Peter Bacsko            	| pbacsko    	| Cloudera     	| +1       	|
-| Tingyao Huang           	| tingyao    	|              	| +8       	|
+| Tingyao Huang           	| tingyao    	| TrendMicro    | +8       	|
 | Yu Teng Chen            	| yuteng     	| NTCU         	| +8       	|
 
 ## Become a Committer


### PR DESCRIPTION
This adds a page at community/people, and a list of PPMC/committer names.
And move "become a committer/PPMC" to this page because it is more relevant.
Sorry forgot to take a screenshot, but I've tested this locally, it works fine. Please help to review the content. Thanks!