### PR TITLE
[YUNIKORN-990] DocSearch Migration

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -258,7 +258,8 @@ Copyright © 2020-${new Date().getFullYear()} <a href="https://www.apache.org/">
 </div>`
     },
     algolia: {
-      apiKey: '65b6e69046d08b5364868a53ff974c2f',
+      appId: 'Q1V951BG2V',
+      apiKey: '9ae3e2f7a01a21300490729dfb9f2a51',
       indexName: 'yunikorn',
       contextualSearch: true,
     },


### PR DESCRIPTION
#Description
Update credentials which are new apiKey and appId of algolia docsearch, according to [Docsearch migration in docusaurus blog](https://docusaurus.io/blog/2021/11/21/algolia-docsearch-migration).

#Build and run(test)
![image](https://user-images.githubusercontent.com/45888688/153696581-063044e6-7622-4ed2-9407-ce1ff7259169.png)